### PR TITLE
BANDA-600 chore: Simplify type for withLogTags()

### DIFF
--- a/.changeset/happy-cougars-flash.md
+++ b/.changeset/happy-cougars-flash.md
@@ -1,0 +1,7 @@
+---
+'workers-tagged-logger': patch
+---
+
+BANDA-600 chore: Simplify type for withLogTags()
+
+This function doesn't need to be async because als.run() is not async.

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -226,10 +226,10 @@ interface WithLogTagsOptions<T extends LogTags> {
  * })
  * ```
  */
-export async function withLogTags<T extends LogTags, R>(
+export function withLogTags<T extends LogTags, R>(
 	opts: WithLogTagsOptions<Partial<T & LogTags>>,
-	fn: () => Promise<R>
-): Promise<R> {
+	fn: () => R
+): R {
 	const existing = als.getStore()
 	let source: { source: string } | undefined
 	const sourceOpt = opts.source
@@ -237,5 +237,5 @@ export async function withLogTags<T extends LogTags, R>(
 		source = { source: sourceOpt }
 	}
 	// Note: existing won't exist when withLogTags() is first called
-	return await als.run(structuredClone(Object.assign({}, existing, source, opts.tags)), fn)
+	return als.run(structuredClone(Object.assign({}, existing, source, opts.tags)), fn)
 }


### PR DESCRIPTION
This function doesn't need to be async because als.run() is not async.