### PR TITLE
BANDA-601 fix: Add node exports to support node targets

### DIFF
--- a/.changeset/rich-suits-buy.md
+++ b/.changeset/rich-suits-buy.md
@@ -1,0 +1,5 @@
+---
+'workers-tagged-logger': patch
+---
+
+BANDA-601 fix: Add node exports to support node targets

--- a/packages/workers-tagged-logger/package.json
+++ b/packages/workers-tagged-logger/package.json
@@ -26,6 +26,10 @@
 		"import": {
 			"types": "./dist/index.d.mts",
 			"default": "./dist/index.mjs"
+		},
+		"node": {
+			"types": "./dist/index.d.mts",
+			"default": "./dist/index.mjs"
 		}
 	},
 	"module": "./dist/index.mjs",


### PR DESCRIPTION
Was having issues building a node app with tsx due to this