### PR TITLE
feat: add minimum logging level to tagged logger

### DIFF
--- a/.changeset/rude-starfishes-run.md
+++ b/.changeset/rude-starfishes-run.md
@@ -1,0 +1,5 @@
+---
+'workers-tagged-logger': patch
+---
+
+Add optional minimum logging level

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -16,6 +16,25 @@ export const LogFields = LogTags
 export type LogLevel = z.infer<typeof LogLevel>
 export const LogLevel = z.enum(['info', 'log', 'warn', 'error', 'debug'])
 
+/**
+ * Converts a string based log-level into a number. Useful for filtering out for
+ * configured log levels.
+ */
+function logLevelToNumber(logLevel: LogLevel): number {
+	switch (logLevel) {
+		case 'debug':
+			return 0
+		case 'info':
+			return 1
+		case 'log':
+			return 1
+		case 'warn':
+			return 2
+		case 'error':
+			return 3
+	}
+}
+
 type LogFn = (...msgs: any[]) => void
 type LogLevelFns = {
 	[K in LogLevel]: LogFn
@@ -45,6 +64,12 @@ export interface WorkersLoggerOptions {
 	 * (or child instance) that log.withFields() was called.
 	 */
 	fields?: LogFields
+	/**
+	 * Minimum log level for logger, inclusive. Logging levels below the minimum set are ignored.
+	 *
+	 * Defaults to the lowest level: `debug`.
+	 */
+	minimumLogLevel?: LogLevel
 }
 
 /**
@@ -145,6 +170,12 @@ export class WorkersLogger<T extends LogTags> implements LogLevelFns {
 	debug = (...msgs: any[]): void => this.write(msgs, 'debug')
 
 	private write(msgs: any[], level: LogLevel): void {
+		const minimumLogLevel = this.ctx.minimumLogLevel ?? 'debug'
+		// don't do anything if log is below minimum level
+		if (logLevelToNumber(level) < logLevelToNumber(minimumLogLevel)) {
+			return
+		}
+
 		const tags = this.getTags()
 		let message: string | undefined
 		if (Array.isArray(msgs)) {


### PR DESCRIPTION
This allows people to set a minimum logging level when creating a logger.

A simple use-case: a user might want to set a worker/DO invocation as DEBUG depending on a header but wants to default to a info level to not clutter the logging target.