### PR TITLE
feat: expose `getTags` as a public method

### DIFF
--- a/.changeset/silent-needles-smoke.md
+++ b/.changeset/silent-needles-smoke.md
@@ -1,0 +1,5 @@
+---
+'workers-tagged-logger': patch
+---
+
+Expose `getTags` as a public method

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -107,7 +107,7 @@ export class WorkersLogger<T extends LogTags> implements LogLevelFns {
 	 * Get global tags stored in async context. Excludes
 	 * tags set on this instance using withTags())
 	 */
-	private getGlobalTags(): Partial<T & LogTags> | undefined {
+	private getParentTags(): Partial<T & LogTags> | undefined {
 		const tags = als.getStore()
 		if (tags === undefined) {
 			console.log({
@@ -123,17 +123,17 @@ export class WorkersLogger<T extends LogTags> implements LogLevelFns {
 	/**
 	 * Get all tags (including global + context tags)
 	 */
-	private getTags(): Partial<T & LogTags> {
-		return Object.assign({}, this.getGlobalTags(), this.ctx.tags) as Partial<T & LogTags>
+	getTags(): Partial<T & LogTags> {
+		return Object.assign({}, this.getParentTags(), this.ctx.tags) as Partial<T & LogTags>
 	}
 
 	/** Set tags used for all logs in this async context
 	 * and any child context (unless overridden using withTags) */
 	setTags(tags: Partial<T & LogTags>): void {
-		const globalTags = this.getGlobalTags()
+		const globalTags = this.getParentTags()
 		if (globalTags !== undefined) {
 			// no need to log when we don't have global tags because
-			// getGlobalTags already logs it.
+			// getParentTags already logs it.
 			Object.assign(globalTags, structuredClone(tags))
 		}
 	}


### PR DESCRIPTION
Basically, in Workers, there are some really
unsual situation where ALS (AsyncLocalStorage) doesn't work - where context is lost.

For instance, it happens when you cross JSRPC
boundaries twice:

DO (caller) <-> Worker (calee) <-> RpcTarget (caller)

RpcTarget in this case will not have the AsyncContext propagated, so we need to inject it in a different way. This PR allows to expose all tags so that we can inject the logger using a different method.