### PR TITLE
fix: Export WithLogTags decorator and simplify signature

### DIFF
--- a/.changeset/short-donuts-destroy.md
+++ b/.changeset/short-donuts-destroy.md
@@ -1,0 +1,9 @@
+---
+'workers-tagged-logger': minor
+---
+
+fix: Export WithLogTags decorator and simplify signature
+
+Forgot to export WithLogTags in 0.6.0 so this fixes that.
+
+Also simplified WithLogTags signature to take either a source string, or an object containing tags.

--- a/packages/workers-tagged-logger/README.md
+++ b/packages/workers-tagged-logger/README.md
@@ -146,7 +146,7 @@ class MyRequestHandler {
 
 	// Decorator can also be used on nested methods
 	// Explicit source overrides inference. Inherits user_id from handle's context.
-	@WithLogTags({ source: 'DataProcessor', tags: { stage: 'processing' } })
+	@WithLogTags({ source: 'DataProcessor', stage: 'processing' })
 	async processData(url: string) {
 		// Logs here get { source: "DataProcessor", $logger..., user_id, stage: "processing" }
 		logger.debug(`Processing data for URL: ${url}`)
@@ -184,7 +184,7 @@ class MyRequestHandler {
     1.  Explicit source provided via `@WithLogTags("MySource")` or `@WithLogTags({ source: "MySource" })`.
     2.  Source inherited from an existing `AsyncLocalStorage` context (e.g., from an outer `withLogTags` or `@WithLogTags` call).
     3.  Inferred from the class name (e.g., `MyRequestHandler`).
-  - `tags`: You can provide additional tags via `@WithLogTags({ tags: {...} })` that will be set for the duration of that method's execution.
+  - `tags`: You can provide additional tags via `@WithLogTags({ source: 'MySource', ... })` that will be set for the duration of that method's execution.
 - **Usage:** Ideal for adding context to specific stages of processing within your classes without manual `withLogTags` wrapping around method calls.
 
 ### Hono Middleware (optional)

--- a/packages/workers-tagged-logger/src/index.ts
+++ b/packages/workers-tagged-logger/src/index.ts
@@ -1,3 +1,3 @@
-export { WorkersLogger, withLogTags, ConsoleLog, LogTags } from './logger.js'
+export { WorkersLogger, withLogTags, WithLogTags, ConsoleLog, LogTags } from './logger.js'
 export type { WorkersLoggerOptions } from './logger.js'
 export { useWorkersLogger, LoggerHonoBindings } from './hono.js'

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -462,7 +462,9 @@ export function WithLogTags<T extends LogTags>(
 			const existing = als.getStore()
 			let rootMethodName = methodName
 			if (
+				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 				existing &&
+				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 				existing.$logger &&
 				typeof existing.$logger === 'object' &&
 				!Array.isArray(existing.$logger) &&

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -269,24 +269,22 @@ export function withLogTags<T extends LogTags, R>(
 	return als.run(newTags, fn)
 }
 
-/** Options for the WithLogTags decorator */
-interface WithLogTagsOptions<T extends LogTags> {
+/** Type alias for the actual decorator function returned */
+type MethodDecoratorFn = (
+	target: any,
+	propertyKey: string | symbol,
+	descriptor: PropertyDescriptor
+) => PropertyDescriptor | void
+
+/** Tags for the WithLogTags decorator */
+type WithLogTagsDecoratorOptions<T extends LogTags> = {
 	/**
 	 * Explicit source for logs. If omitted, the class name containing the
 	 * decorated method will automatically be used as the source.
 	 * @default Class name
 	 */
 	source?: string
-	/** Additional tags to set for the duration of the decorated method's execution */
-	tags?: Partial<T & LogTags>
-}
-
-// Type alias for the actual decorator function returned
-type MethodDecoratorFn = (
-	target: any,
-	propertyKey: string | symbol,
-	descriptor: PropertyDescriptor
-) => PropertyDescriptor | void
+} & Partial<T & LogTags>
 
 /**
  * Decorator: Wraps a class method with logging context.
@@ -310,7 +308,7 @@ type MethodDecoratorFn = (
  *   \@WithLogTags() // $logger.methodName: 'handleRequest' will be added
  *   async handleRequest(requestId: string, request: Request) {
  *     logger.setTags({ requestId })
- *     logger.info('Handling request') // -> tags: { source: 'MyService', '$logger.methodName': 'handleRequest', requestId: '...' }
+ *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger: { methodName: 'handleRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
  *     await this.processRequest(request)
  *     logger.info('Request handled')
  *   }
@@ -319,8 +317,8 @@ type MethodDecoratorFn = (
  *   // and $logger.rootMethodName will remain 'handleRequest'
  *   \@WithLogTags()
  *   async processRequest(request: Request) {
- *      // Inherits requestId from handleRequest's context
- *      // Tags here: { source: 'MyService', '$logger.methodName': 'processRequest', '$logger.rootMethodName': 'handleRequest', requestId: '...' }
+ *     // Inherits requestId from handleRequest's context
+ *     // Tags here: { source: 'MyService', $logger: { methodName: 'processRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
  *     logger.debug('Processing request...')
  *     // ...
  *     logger.debug('Request processed')
@@ -353,7 +351,7 @@ export function WithLogTags(): MethodDecoratorFn
  *   \@WithLogTags<MyTags>('MyService') // $logger.methodName: 'handleRequest' will be added
  *   async handleRequest(requestId: string, request: Request) {
  *     logger.setTags({ requestId })
- *     logger.info('Handling request') // -> tags: { source: 'MyService', '$logger.methodName': 'handleRequest', requestId: '...' }
+ *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger: { methodName: 'handleRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
  *     await this.processRequest(request)
  *     logger.info('Request handled')
  *   }
@@ -363,7 +361,7 @@ export function WithLogTags(): MethodDecoratorFn
  *   \@WithLogTags<MyTags>('MyServiceHelper')
  *   async processRequest(request: Request) {
  *      // Inherits requestId from handleRequest's context
- *      // Tags here: { source: 'MyServiceHelper', '$logger.methodName': 'processRequest', '$logger.rootMethodName': 'handleRequest', requestId: '...' }
+ *       Tags here: { source: 'MyServiceHelper', $logger: { methodName: 'processRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
  *     logger.debug('Processing request...')
  *     // ...
  *     logger.debug('Request processed')
@@ -383,10 +381,9 @@ export function WithLogTags(source: string): MethodDecoratorFn
  *   - `$logger.rootMethodName`: The name of the first decorated method entered in the async context.
  * Nested calls will inherit metadata.
  *
- * @param opts Options including source and initial tags.
- * @param opts.source Tag for the source of these logs (e.g., the Worker name or class name). Falls back to Class Name
- * @param opts.tags Additional tags to set for this context. User-provided tags
- *                  will override existing tags but NOT the automatically added logger tags.
+ * @param tags Additional tags to set for this context. User-provided tags
+ *             will override existing tags but NOT the automatically added logger tags.
+ * @param tags.source Tag for the source of these logs (e.g., the Worker name or class name). Falls back to Class Name
  *
  * @example
  *
@@ -399,17 +396,17 @@ export function WithLogTags(source: string): MethodDecoratorFn
  *   \@WithLogTags<MyTags>({ source: 'MyService' }) // $logger.methodName: 'handleRequest' will be added
  *   async handleRequest(requestId: string, request: Request) {
  *     logger.setTags({ requestId })
- *     logger.info('Handling request') // -> tags: { source: 'MyService', '$logger.methodName': 'handleRequest', requestId: '...' }
+ *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger.methodName: 'handleRequest', requestId: '...' }
  *     await this.processRequest(request)
  *     logger.info('Request handled')
  *   }
  *
  *   // $logger.methodName: 'processRequest' will be added
  *   // and $logger.rootMethodName will remain 'handleRequest'
- *   \@WithLogTags<MyTags>({ tags: { foo: 'bar' } })
+ *   \@WithLogTags<MyTags>({ foo: 'bar' })
  *   async processRequest(request: Request) {
  *      // Inherits requestId from handleRequest's context
- *      // Tags here: { source: 'MyService', foo: 'bar', '$logger.methodName': 'processRequest', '$logger.rootMethodName': 'handleRequest', requestId: '...' }
+ *      // Tags here: { source: 'MyService', foo: 'bar', $logger.methodName: 'processRequest', $logger.rootMethodName: 'handleRequest', requestId: '...' }
  *     logger.debug('Processing request...')
  *     // ...
  *     logger.debug('Request processed')
@@ -418,11 +415,11 @@ export function WithLogTags(source: string): MethodDecoratorFn
  * ```
  */
 export function WithLogTags<T extends LogTags>(
-	opts: WithLogTagsOptions<Partial<T & LogTags>>
+	tags: WithLogTagsDecoratorOptions<Partial<T & LogTags>>
 ): MethodDecoratorFn
 export function WithLogTags<T extends LogTags>(
 	/** Optional configuration: string is explicit source, object allows source/tags, undefined uses class name */
-	optsOrSource?: string | WithLogTagsOptions<Partial<T & LogTags>>
+	sourceOrTags?: string | WithLogTagsDecoratorOptions<Partial<T & LogTags>>
 ): MethodDecoratorFn {
 	// This is the function returned that acts as the decorator
 	return function (
@@ -442,11 +439,11 @@ export function WithLogTags<T extends LogTags>(
 		let explicitSource: string | undefined
 		let userTags: LogTags | undefined
 
-		if (typeof optsOrSource === 'string') {
-			explicitSource = optsOrSource
-		} else if (optsOrSource) {
-			explicitSource = optsOrSource.source
-			userTags = optsOrSource.tags
+		if (typeof sourceOrTags === 'string') {
+			explicitSource = sourceOrTags
+		} else if (sourceOrTags) {
+			explicitSource = sourceOrTags.source
+			userTags = sourceOrTags
 		}
 
 		let inferredClassName: string | undefined = 'UnknownClass'
@@ -463,15 +460,26 @@ export function WithLogTags<T extends LogTags>(
 
 		descriptor.value = function (...args: any[]): MethodDecoratorFn {
 			const existing = als.getStore()
-			const rootMethodName = existing?.['$logger.rootMethodName'] ?? methodName
+			let rootMethodName = methodName
+			if (
+				existing &&
+				existing.$logger &&
+				typeof existing.$logger === 'object' &&
+				!Array.isArray(existing.$logger) &&
+				typeof existing.$logger.rootMethodName === 'string'
+			) {
+				rootMethodName = existing.$logger.rootMethodName
+			}
 
 			const finalSource = explicitSource ?? existing?.source ?? inferredClassName
 			const sourceTag = { source: finalSource }
 
 			// Define the logger-specific tags for this context level
 			const loggerTags = {
-				'$logger.methodName': methodName, // Always the current method
-				'$logger.rootMethodName': rootMethodName, // Inherited or current
+				$logger: {
+					methodName: methodName, // Always the current method
+					rootMethodName: rootMethodName, // Inherited or current
+				},
 			}
 
 			// Create the new tags object for the ALS context

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -277,7 +277,7 @@ type MethodDecoratorFn = (
 ) => PropertyDescriptor | void
 
 /** Tags for the WithLogTags decorator */
-type WithLogTagsDecoratorOptions<T extends LogTags> = {
+type WithLogTagsDecoratorTags<T extends LogTags> = {
 	/**
 	 * Explicit source for logs. If omitted, the class name containing the
 	 * decorated method will automatically be used as the source.
@@ -415,11 +415,11 @@ export function WithLogTags(source: string): MethodDecoratorFn
  * ```
  */
 export function WithLogTags<T extends LogTags>(
-	tags: WithLogTagsDecoratorOptions<Partial<T & LogTags>>
+	tags: WithLogTagsDecoratorTags<Partial<T & LogTags>>
 ): MethodDecoratorFn
 export function WithLogTags<T extends LogTags>(
 	/** Optional configuration: string is explicit source, object allows source/tags, undefined uses class name */
-	sourceOrTags?: string | WithLogTagsDecoratorOptions<Partial<T & LogTags>>
+	sourceOrTags?: string | WithLogTagsDecoratorTags<Partial<T & LogTags>>
 ): MethodDecoratorFn {
 	// This is the function returned that acts as the decorator
 	return function (

--- a/packages/workers-tagged-logger/src/test/logger/decorator.spec.ts
+++ b/packages/workers-tagged-logger/src/test/logger/decorator.spec.ts
@@ -1,28 +1,29 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { describe, expect, it } from 'vitest'
-
-import { withLogTags, WithLogTags, type LogTags } from '../../logger.js'
-import { setupTest } from '../harness.js'
-
-import type { TestHarness } from '../harness.js'
 import { z } from 'zod'
 
+import { withLogTags, WithLogTags } from '../../logger.js'
+import { setupTest } from '../harness.js'
+
+import type { LogTags } from '../../logger.js'
+import type { TestHarness } from '../harness.js'
+
 describe('@WithLogTags', () => {
-	type TestTags =  z.infer<typeof TestTags>
+	type TestTags = z.infer<typeof TestTags>
 	const TestTags = z.object({
 		requestId: z.string().optional(),
 		userId: z.number().optional(),
 		source: z.string().optional(),
 		$logger: z.object({
 			methodName: z.string().optional(),
-			rootMethodName: z.string().optional()
+			rootMethodName: z.string().optional(),
 		}),
 		customTag: z.string().optional(),
-		overrideMe: z.string().optional()
+		overrideMe: z.string().optional(),
 	})
 
 	function toTags(tags: LogTags | undefined): TestTags | undefined {
-			return TestTags.passthrough().parse(tags)
+		return TestTags.passthrough().parse(tags)
 	}
 
 	class TestService {
@@ -156,7 +157,7 @@ describe('@WithLogTags', () => {
 			this.h.log.info('Instance method with inferred source (empty options)')
 		}
 
-		@WithLogTags({  only: 'tags'  }) // Only tags, source should be inferred
+		@WithLogTags({ only: 'tags' }) // Only tags, source should be inferred
 		inferredSourceOnlyTags() {
 			this.h.log.info('Instance method with inferred source (only tags)')
 		}
@@ -460,8 +461,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(1).tags).toEqual({
 			source: 'SyncSource', // Overrides caller's source
 			$logger: {
-				methodName: 'synchronousMethod',// Current method
-				rootMethodName: 'synchronousCaller',// Root is the caller
+				methodName: 'synchronousMethod', // Current method
+				rootMethodName: 'synchronousCaller', // Root is the caller
 			},
 			syncTag: true, // Added by synchronousMethod decorator
 		})

--- a/packages/workers-tagged-logger/src/test/logger/decorator.spec.ts
+++ b/packages/workers-tagged-logger/src/test/logger/decorator.spec.ts
@@ -1,20 +1,28 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { describe, expect, it } from 'vitest'
 
-import { withLogTags, WithLogTags } from '../../logger.js'
+import { withLogTags, WithLogTags, type LogTags } from '../../logger.js'
 import { setupTest } from '../harness.js'
 
 import type { TestHarness } from '../harness.js'
+import { z } from 'zod'
 
 describe('@WithLogTags', () => {
-	type TestTags = {
-		requestId?: string
-		userId?: number
-		source?: string
-		'$logger.methodName'?: string
-		'$logger.rootMethodName'?: string
-		customTag?: string
-		overrideMe?: string
+	type TestTags =  z.infer<typeof TestTags>
+	const TestTags = z.object({
+		requestId: z.string().optional(),
+		userId: z.number().optional(),
+		source: z.string().optional(),
+		$logger: z.object({
+			methodName: z.string().optional(),
+			rootMethodName: z.string().optional()
+		}),
+		customTag: z.string().optional(),
+		overrideMe: z.string().optional()
+	})
+
+	function toTags(tags: LogTags | undefined): TestTags | undefined {
+			return TestTags.passthrough().parse(tags)
 	}
 
 	class TestService {
@@ -37,7 +45,7 @@ describe('@WithLogTags', () => {
 
 		// Adding tag hints is not required. It's only
 		// helpful if tags are specified
-		@WithLogTags<TestTags>({ tags: { customTag: 'nestedValue' } })
+		@WithLogTags<TestTags>({ customTag: 'nestedValue' })
 		async nestedMethod(userId: number) {
 			this.h.log.setTags({ userId })
 			this.h.log.info('Entering nestedMethod')
@@ -91,19 +99,19 @@ describe('@WithLogTags', () => {
 		}
 
 		// Method to test tag override precedence
-		@WithLogTags({
-			tags: {
-				'$logger.methodName': 'userAttempt', // Should be overridden
-				'$logger.rootMethodName': 'userAttemptRoot', // Should be overridden
-				overrideMe: 'decoratorValue',
+		@WithLogTags<TestTags>({
+			$logger: {
+				methodName: 'userAttempt', // Should be overridden
+				rootMethodName: 'userAttemptRoot', // Should be overridden
 			},
+			overrideMe: 'decoratorValue',
 		})
 		async methodWithTagOverrides() {
 			this.h.log.setTags({ overrideMe: 'setTagsValue' }) // setTags overrides decorator opts.tags
 			this.h.log.info('Testing tag overrides')
 		}
 
-		@WithLogTags({ source: 'SyncSource', tags: { syncTag: true } })
+		@WithLogTags({ source: 'SyncSource', syncTag: true })
 		synchronousMethod(value: number): string {
 			this.h.log.info(`Entering synchronousMethod with value: ${value}`)
 			const result = `Sync result: ${value * 2}`
@@ -148,7 +156,7 @@ describe('@WithLogTags', () => {
 			this.h.log.info('Instance method with inferred source (empty options)')
 		}
 
-		@WithLogTags({ tags: { only: 'tags' } }) // Only tags, source should be inferred
+		@WithLogTags({  only: 'tags'  }) // Only tags, source should be inferred
 		inferredSourceOnlyTags() {
 			this.h.log.info('Instance method with inferred source (only tags)')
 		}
@@ -211,8 +219,10 @@ describe('@WithLogTags', () => {
 
 		expect(h.logAt(0).tags).toEqual({
 			source: 'TestServiceEntry',
-			'$logger.methodName': 'entryPoint',
-			'$logger.rootMethodName': 'entryPoint',
+			$logger: {
+				methodName: 'entryPoint',
+				rootMethodName: 'entryPoint',
+			},
 			requestId: 'req-1',
 		})
 		expect(h.logAt(0).message).toBe('Entering entryPoint')
@@ -237,8 +247,10 @@ describe('@WithLogTags', () => {
 		// 1. First log in entryPoint
 		expect(h.logAt(0).tags).toEqual({
 			source: 'TestServiceEntry',
-			'$logger.methodName': 'entryPoint',
-			'$logger.rootMethodName': 'entryPoint',
+			$logger: {
+				methodName: 'entryPoint',
+				rootMethodName: 'entryPoint',
+			},
 			requestId: 'req-2',
 		})
 		expect(h.logAt(0).message).toBe('Entering entryPoint')
@@ -246,8 +258,10 @@ describe('@WithLogTags', () => {
 		// 2. First log in nestedMethod
 		expect(h.logAt(1).tags).toEqual({
 			source: 'TestServiceEntry', // Inherited source
-			'$logger.methodName': 'nestedMethod', // Current method
-			'$logger.rootMethodName': 'entryPoint', // Root method
+			$logger: {
+				methodName: 'nestedMethod',
+				rootMethodName: 'entryPoint',
+			},
 			requestId: 'req-2', // Inherited from entryPoint context
 			customTag: 'nestedValue', // From decorator options
 			userId: 123, // Set in nestedMethod
@@ -261,8 +275,10 @@ describe('@WithLogTags', () => {
 		// 4. First log in deeplyNestedMethod
 		expect(h.logAt(3).tags).toEqual({
 			source: 'DeepNestedSource', // Overridden source
-			'$logger.methodName': 'deeplyNestedMethod', // Current method
-			'$logger.rootMethodName': 'entryPoint', // Root method
+			$logger: {
+				methodName: 'deeplyNestedMethod',
+				rootMethodName: 'entryPoint',
+			},
 			requestId: 'req-2', // Inherited
 			customTag: 'nestedValue', // Inherited
 			userId: 123, // Inherited
@@ -293,8 +309,10 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(8).tags).toEqual({
 			// Should not include tags set in nested contexts
 			source: 'TestServiceEntry',
-			'$logger.methodName': 'entryPoint',
-			'$logger.rootMethodName': 'entryPoint',
+			$logger: {
+				methodName: 'entryPoint',
+				rootMethodName: 'entryPoint',
+			},
 			requestId: 'req-2',
 			// no customTag or userId that were set in nested call
 		})
@@ -312,8 +330,10 @@ describe('@WithLogTags', () => {
 
 		expect(h.oneLog().message).toBe('this.instanceValue is now: modified')
 		expect(h.oneLog().tags).toEqual({
-			'$logger.methodName': 'methodAccessingThis',
-			'$logger.rootMethodName': 'methodAccessingThis',
+			$logger: {
+				methodName: 'methodAccessingThis',
+				rootMethodName: 'methodAccessingThis',
+			},
 			source: 'TestService', // inferred
 		})
 	})
@@ -337,8 +357,10 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(0).message).toBe('Entering staticMethod with value: test-val')
 		expect(h.logAt(0).tags).toEqual({
 			source: 'StaticContext',
-			'$logger.methodName': 'staticMethod',
-			'$logger.rootMethodName': 'staticMethod',
+			$logger: {
+				methodName: 'staticMethod',
+				rootMethodName: 'staticMethod',
+			},
 		})
 		expect(h.logAt(1).message).toBe('Exiting staticMethod')
 		expect(h.logAt(1).tags).toEqual(h.logAt(0).tags)
@@ -354,8 +376,10 @@ describe('@WithLogTags', () => {
 		expect(h.oneLog().message).toBe('About to throw error')
 		expect(h.oneLog().tags).toEqual({
 			source: 'ErrorSource',
-			'$logger.methodName': 'methodWithError',
-			'$logger.rootMethodName': 'methodWithError',
+			$logger: {
+				methodName: 'methodWithError',
+				rootMethodName: 'methodWithError',
+			},
 		})
 	})
 
@@ -367,8 +391,10 @@ describe('@WithLogTags', () => {
 
 		expect(h.oneLog().tags).toEqual({
 			// $logger tags take precedence over decorator opts.tags
-			'$logger.methodName': 'methodWithTagOverrides',
-			'$logger.rootMethodName': 'methodWithTagOverrides',
+			$logger: {
+				methodName: 'methodWithTagOverrides',
+				rootMethodName: 'methodWithTagOverrides',
+			},
 			// setTags takes precedence over decorator opts.tags
 			overrideMe: 'setTagsValue',
 			source: 'TestService', // inferred
@@ -398,8 +424,10 @@ describe('@WithLogTags', () => {
 		// Check logs have correct context
 		const expectedTags = {
 			source: 'SyncSource',
-			'$logger.methodName': 'synchronousMethod',
-			'$logger.rootMethodName': 'synchronousMethod',
+			$logger: {
+				methodName: 'synchronousMethod',
+				rootMethodName: 'synchronousMethod',
+			},
 			syncTag: true,
 		}
 		expect(h.logAt(0).message).toBe('Entering synchronousMethod with value: 10')
@@ -421,16 +449,20 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(0).message).toBe('Entering synchronousCaller with value: 5')
 		expect(h.logAt(0).tags).toEqual({
 			source: 'SyncCaller',
-			'$logger.methodName': 'synchronousCaller',
-			'$logger.rootMethodName': 'synchronousCaller',
+			$logger: {
+				methodName: 'synchronousCaller',
+				rootMethodName: 'synchronousCaller',
+			},
 		})
 
 		// Log 2: Entry to synchronousMethod (called from synchronousCaller)
 		expect(h.logAt(1).message).toBe('Entering synchronousMethod with value: 6')
 		expect(h.logAt(1).tags).toEqual({
 			source: 'SyncSource', // Overrides caller's source
-			'$logger.methodName': 'synchronousMethod', // Current method
-			'$logger.rootMethodName': 'synchronousCaller', // Root is the caller
+			$logger: {
+				methodName: 'synchronousMethod',// Current method
+				rootMethodName: 'synchronousCaller',// Root is the caller
+			},
 			syncTag: true, // Added by synchronousMethod decorator
 		})
 
@@ -444,8 +476,10 @@ describe('@WithLogTags', () => {
 			// Context restored to synchronousCaller's context
 			// excluding tags added by the nested call's decorator
 			source: 'SyncCaller',
-			'$logger.methodName': 'synchronousCaller',
-			'$logger.rootMethodName': 'synchronousCaller',
+			$logger: {
+				methodName: 'synchronousCaller',
+				rootMethodName: 'synchronousCaller',
+			},
 		})
 	})
 
@@ -460,8 +494,10 @@ describe('@WithLogTags', () => {
 
 		expect(h.oneLog().message).toBe('this.syncInstanceValue is now: sync modified')
 		expect(h.oneLog().tags).toEqual({
-			'$logger.methodName': 'syncMethodAccessingThis',
-			'$logger.rootMethodName': 'syncMethodAccessingThis',
+			$logger: {
+				methodName: 'syncMethodAccessingThis',
+				rootMethodName: 'syncMethodAccessingThis',
+			},
 			source: 'TestService', // inferred
 		})
 	})
@@ -473,8 +509,8 @@ describe('@WithLogTags', () => {
 			service.inferredSourceInstanceMethod()
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('inferredSourceInstanceMethod')
-			expect(h.oneLog().tags?.['$logger.rootMethodName']).toBe('inferredSourceInstanceMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceInstanceMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('inferredSourceInstanceMethod')
 		})
 
 		it('should infer source from class name for static method when no options provided', () => {
@@ -482,8 +518,8 @@ describe('@WithLogTags', () => {
 			TestService.inferredSourceStaticMethod(h)
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('inferredSourceStaticMethod')
-			expect(h.oneLog().tags?.['$logger.rootMethodName']).toBe('inferredSourceStaticMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceStaticMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('inferredSourceStaticMethod')
 		})
 
 		it('should infer source from class name when empty options object provided', () => {
@@ -492,7 +528,7 @@ describe('@WithLogTags', () => {
 			service.inferredSourceEmptyOptions()
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('inferredSourceEmptyOptions')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceEmptyOptions')
 		})
 
 		it('should infer source from class name when only tags option provided', () => {
@@ -502,7 +538,7 @@ describe('@WithLogTags', () => {
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
 			expect(h.oneLog().tags?.only).toBe('tags') // Verify tag is also present
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('inferredSourceOnlyTags')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceOnlyTags')
 		})
 
 		it('should use explicit source from options object over inferred class name', () => {
@@ -511,7 +547,7 @@ describe('@WithLogTags', () => {
 			service.explicitSourceViaObject()
 
 			expect(h.oneLog().tags?.source).toBe('ExplicitSourceFromObject')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('explicitSourceViaObject')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceViaObject')
 		})
 
 		it('should use explicit source from string argument over inferred class name', () => {
@@ -520,7 +556,7 @@ describe('@WithLogTags', () => {
 			service.explicitSourceViaString()
 
 			expect(h.oneLog().tags?.source).toBe('ExplicitSourceFromString')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('explicitSourceViaString')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceViaString')
 		})
 
 		it('should use explicit source for static method when provided', () => {
@@ -528,7 +564,7 @@ describe('@WithLogTags', () => {
 			TestService.explicitSourceStaticMethod(h)
 
 			expect(h.oneLog().tags?.source).toBe('ExplicitStaticSource')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('explicitSourceStaticMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceStaticMethod')
 		})
 	})
 
@@ -542,14 +578,14 @@ describe('@WithLogTags', () => {
 			// Log 1: Outer method with its explicit source
 			expect(h.logAt(0).message).toBe('Entering outer explicit')
 			expect(h.logAt(0).tags?.source).toBe('OuterExplicitSource')
-			expect(h.logAt(0).tags?.['$logger.methodName']).toBe('callNestedInferredSource')
+			expect(toTags(h.logAt(0).tags)?.$logger.methodName).toBe('callNestedInferredSource')
 
 			// Log 2: Inner method (@WithLogTags() - no explicit source)
 			// Should inherit 'OuterExplicitSource' from the ALS context
 			expect(h.logAt(1).message).toBe('Entering nested inferred (should inherit)')
 			expect(h.logAt(1).tags?.source).toBe('OuterExplicitSource') // Inherited
-			expect(h.logAt(1).tags?.['$logger.methodName']).toBe('nestedInferredSource') // Own method name
-			expect(h.logAt(1).tags?.['$logger.rootMethodName']).toBe('callNestedInferredSource') // Root is the caller
+			expect(toTags(h.logAt(1).tags)?.$logger.methodName).toBe('nestedInferredSource') // Own method name
+			expect(toTags(h.logAt(1).tags)?.$logger.rootMethodName).toBe('callNestedInferredSource') // Root is the caller
 
 			// Log 3: Back in outer method
 			expect(h.logAt(2).message).toBe('Exiting outer explicit')
@@ -570,7 +606,7 @@ describe('@WithLogTags', () => {
 			// Should use its own explicit source, overriding the inherited one
 			expect(h.logAt(1).message).toBe('Entering nested explicit (should override)')
 			expect(h.logAt(1).tags?.source).toBe('InnerExplicitSource') // Overridden
-			expect(h.logAt(1).tags?.['$logger.methodName']).toBe('nestedExplicitSource')
+			expect(toTags(h.logAt(1).tags)?.$logger.methodName).toBe('nestedExplicitSource')
 
 			// Log 3: Back in outer method
 			expect(h.logAt(2).message).toBe('Exiting outer explicit')
@@ -587,8 +623,8 @@ describe('@WithLogTags', () => {
 
 			expect(h.oneLog().message).toBe('Running generic inferred method')
 			expect(h.oneLog().tags?.source).toBe('TestService') // Inferred from class
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('genericInferredMethod')
-			expect(h.oneLog().tags?.['$logger.rootMethodName']).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('genericInferredMethod')
 		})
 
 		it('should inherit source from withLogTags context if decorator has no explicit source', async () => {
@@ -603,9 +639,9 @@ describe('@WithLogTags', () => {
 			expect(h.oneLog().message).toBe('Running generic inferred method')
 			// Should inherit source from the withLogTags context
 			expect(h.oneLog().tags?.source).toBe('FromWithLogTags')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('genericInferredMethod')
 			// Root method name starts when the first decorator runs
-			expect(h.oneLog().tags?.['$logger.rootMethodName']).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('genericInferredMethod')
 		})
 
 		it('should use decorator explicit source even when called from withLogTags context', async () => {
@@ -620,8 +656,8 @@ describe('@WithLogTags', () => {
 			expect(h.oneLog().message).toBe('Instance method with explicit source (object)')
 			// Decorator's explicit source should take precedence over withLogTags context
 			expect(h.oneLog().tags?.source).toBe('ExplicitSourceFromObject')
-			expect(h.oneLog().tags?.['$logger.methodName']).toBe('explicitSourceViaObject')
-			expect(h.oneLog().tags?.['$logger.rootMethodName']).toBe('explicitSourceViaObject')
+			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceViaObject')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('explicitSourceViaObject')
 		})
 	})
 })


### PR DESCRIPTION
Forgot to export WithLogTags in 0.6.0 so this fixes that.

Also simplified WithLogTags signature to take either a source string, or
an object containing tags.
