### PR TITLE
chore: rename methodName -> method and rootMethodName -> rootMethod

### DIFF
--- a/.changeset/thirty-lies-nail.md
+++ b/.changeset/thirty-lies-nail.md
@@ -1,0 +1,7 @@
+---
+'workers-tagged-logger': minor
+---
+
+chore: rename methodName -> method and rootMethodName -> rootMethod
+
+this will save a lot of bytes in the long run

--- a/packages/workers-tagged-logger/README.md
+++ b/packages/workers-tagged-logger/README.md
@@ -178,8 +178,8 @@ class MyRequestHandler {
 
 - **Context:** Automatically wraps the method execution in `als.run`.
 - **Tags:**
-  - `$logger.methodName`: Automatically added, showing the name of the decorated method.
-  - `$logger.rootMethodName`: Automatically added, showing the name of the _first_ decorated method entered in the current async call chain.
+  - `$logger.method`: Automatically added, showing the name of the decorated method.
+  - `$logger.rootMethod`: Automatically added, showing the name of the _first_ decorated method entered in the current async call chain.
   - `source`: Automatically added. Precedence:
     1.  Explicit source provided via `@WithLogTags("MySource")` or `@WithLogTags({ source: "MySource" })`.
     2.  Source inherited from an existing `AsyncLocalStorage` context (e.g., from an outer `withLogTags` or `@WithLogTags` call).

--- a/packages/workers-tagged-logger/src/logger.ts
+++ b/packages/workers-tagged-logger/src/logger.ts
@@ -293,8 +293,8 @@ type WithLogTagsDecoratorTags<T extends LogTags> = {
  * **IMPORTANT**: Requires `"experimentalDecorators": true` to be added to tsconfig.json
  *
  * Automatically adds:
- *   - `$logger.methodName`: The name of the currently executing decorated method.
- *   - `$logger.rootMethodName`: The name of the first decorated method entered in the async context.
+ *   - `$logger.method`: The name of the currently executing decorated method.
+ *   - `$logger.rootMethod`: The name of the first decorated method entered in the async context.
  * Nested calls will inherit metadata.
  *
  * @example
@@ -305,20 +305,20 @@ type WithLogTagsDecoratorTags<T extends LogTags> = {
  * // ... imports and logger setup ...
  * class MyService {
  *   // remove the \ before the @ (this is a workaround for VS Code docstring issues)
- *   \@WithLogTags() // $logger.methodName: 'handleRequest' will be added
+ *   \@WithLogTags() // $logger.method: 'handleRequest' will be added
  *   async handleRequest(requestId: string, request: Request) {
  *     logger.setTags({ requestId })
- *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger: { methodName: 'handleRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
+ *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger: { method: 'handleRequest', rootMethod: 'handleRequest' }, requestId: '...' }
  *     await this.processRequest(request)
  *     logger.info('Request handled')
  *   }
  *
- *   // $logger.methodName: 'processRequest' will be added
- *   // and $logger.rootMethodName will remain 'handleRequest'
+ *   // $logger.method: 'processRequest' will be added
+ *   // and $logger.rootMethod will remain 'handleRequest'
  *   \@WithLogTags()
  *   async processRequest(request: Request) {
  *     // Inherits requestId from handleRequest's context
- *     // Tags here: { source: 'MyService', $logger: { methodName: 'processRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
+ *     // Tags here: { source: 'MyService', $logger: { method: 'processRequest', rootMethod: 'handleRequest' }, requestId: '...' }
  *     logger.debug('Processing request...')
  *     // ...
  *     logger.debug('Request processed')
@@ -334,8 +334,8 @@ export function WithLogTags(): MethodDecoratorFn
  * **IMPORTANT**: Requires `"experimentalDecorators": true` to be added to tsconfig.json
  *
  * Automatically adds:
- *   - `$logger.methodName`: The name of the currently executing decorated method.
- *   - `$logger.rootMethodName`: The name of the first decorated method entered in the async context.
+ *   - `$logger.method`: The name of the currently executing decorated method.
+ *   - `$logger.rootMethod`: The name of the first decorated method entered in the async context.
  * Nested calls will inherit metadata.
  *
  * @param source Explicit source for logs.
@@ -348,20 +348,20 @@ export function WithLogTags(): MethodDecoratorFn
  * // ... imports and logger setup ...
  * class MyService {
  *   // remove the \ before the @ (this is a workaround for VS Code docstring issues)
- *   \@WithLogTags<MyTags>('MyService') // $logger.methodName: 'handleRequest' will be added
+ *   \@WithLogTags<MyTags>('MyService') // $logger.method: 'handleRequest' will be added
  *   async handleRequest(requestId: string, request: Request) {
  *     logger.setTags({ requestId })
- *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger: { methodName: 'handleRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
+ *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger: { method: 'handleRequest', rootMethod: 'handleRequest' }, requestId: '...' }
  *     await this.processRequest(request)
  *     logger.info('Request handled')
  *   }
  *
- *   // $logger.methodName: 'processRequest' will be added
- *   // and $logger.rootMethodName will remain 'handleRequest'
+ *   // $logger.method: 'processRequest' will be added
+ *   // and $logger.rootMethod will remain 'handleRequest'
  *   \@WithLogTags<MyTags>('MyServiceHelper')
  *   async processRequest(request: Request) {
  *      // Inherits requestId from handleRequest's context
- *       Tags here: { source: 'MyServiceHelper', $logger: { methodName: 'processRequest', rootMethodName: 'handleRequest' }, requestId: '...' }
+ *       Tags here: { source: 'MyServiceHelper', $logger: { method: 'processRequest', rootMethod: 'handleRequest' }, requestId: '...' }
  *     logger.debug('Processing request...')
  *     // ...
  *     logger.debug('Request processed')
@@ -377,8 +377,8 @@ export function WithLogTags(source: string): MethodDecoratorFn
  * **IMPORTANT**: Requires `"experimentalDecorators": true` to be added to tsconfig.json
  *
  * Automatically adds:
- *   - `$logger.methodName`: The name of the currently executing decorated method.
- *   - `$logger.rootMethodName`: The name of the first decorated method entered in the async context.
+ *   - `$logger.method`: The name of the currently executing decorated method.
+ *   - `$logger.rootMethod`: The name of the first decorated method entered in the async context.
  * Nested calls will inherit metadata.
  *
  * @param tags Additional tags to set for this context. User-provided tags
@@ -393,20 +393,20 @@ export function WithLogTags(source: string): MethodDecoratorFn
  * // ... imports and logger setup ...
  * class MyService {
  *   // remove the \ before the @ (this is a workaround for VS Code docstring issues)
- *   \@WithLogTags<MyTags>({ source: 'MyService' }) // $logger.methodName: 'handleRequest' will be added
+ *   \@WithLogTags<MyTags>({ source: 'MyService' }) // $logger.method: 'handleRequest' will be added
  *   async handleRequest(requestId: string, request: Request) {
  *     logger.setTags({ requestId })
- *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger.methodName: 'handleRequest', requestId: '...' }
+ *     logger.info('Handling request') // -> tags: { source: 'MyService', $logger.method: 'handleRequest', requestId: '...' }
  *     await this.processRequest(request)
  *     logger.info('Request handled')
  *   }
  *
- *   // $logger.methodName: 'processRequest' will be added
- *   // and $logger.rootMethodName will remain 'handleRequest'
+ *   // $logger.method: 'processRequest' will be added
+ *   // and $logger.rootMethod will remain 'handleRequest'
  *   \@WithLogTags<MyTags>({ foo: 'bar' })
  *   async processRequest(request: Request) {
  *      // Inherits requestId from handleRequest's context
- *      // Tags here: { source: 'MyService', foo: 'bar', $logger.methodName: 'processRequest', $logger.rootMethodName: 'handleRequest', requestId: '...' }
+ *      // Tags here: { source: 'MyService', foo: 'bar', $logger.method: 'processRequest', $logger.rootMethod: 'handleRequest', requestId: '...' }
  *     logger.debug('Processing request...')
  *     // ...
  *     logger.debug('Request processed')
@@ -427,12 +427,12 @@ export function WithLogTags<T extends LogTags>(
 		propertyKey: string | symbol,
 		descriptor: PropertyDescriptor
 	): PropertyDescriptor {
-		const methodName = String(propertyKey)
+		const method = String(propertyKey)
 
 		// Validate descriptor (ensure it's a method)
 		if (descriptor === undefined || typeof descriptor.value !== 'function') {
 			throw new Error(
-				`@WithLogTags decorator can only be applied to methods, not properties like ${methodName}.`
+				`@WithLogTags decorator can only be applied to methods, not properties like ${method}.`
 			)
 		}
 
@@ -460,7 +460,7 @@ export function WithLogTags<T extends LogTags>(
 
 		descriptor.value = function (...args: any[]): MethodDecoratorFn {
 			const existing = als.getStore()
-			let rootMethodName = methodName
+			let rootMethod = method
 			if (
 				// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 				existing &&
@@ -468,9 +468,9 @@ export function WithLogTags<T extends LogTags>(
 				existing.$logger &&
 				typeof existing.$logger === 'object' &&
 				!Array.isArray(existing.$logger) &&
-				typeof existing.$logger.rootMethodName === 'string'
+				typeof existing.$logger.rootMethod === 'string'
 			) {
-				rootMethodName = existing.$logger.rootMethodName
+				rootMethod = existing.$logger.rootMethod
 			}
 
 			const finalSource = explicitSource ?? existing?.source ?? inferredClassName
@@ -479,8 +479,8 @@ export function WithLogTags<T extends LogTags>(
 			// Define the logger-specific tags for this context level
 			const loggerTags = {
 				$logger: {
-					methodName: methodName, // Always the current method
-					rootMethodName: rootMethodName, // Inherited or current
+					method: method, // Always the current method
+					rootMethod: rootMethod, // Inherited or current
 				},
 			}
 

--- a/packages/workers-tagged-logger/src/test/logger/decorator.spec.ts
+++ b/packages/workers-tagged-logger/src/test/logger/decorator.spec.ts
@@ -15,8 +15,8 @@ describe('@WithLogTags', () => {
 		userId: z.number().optional(),
 		source: z.string().optional(),
 		$logger: z.object({
-			methodName: z.string().optional(),
-			rootMethodName: z.string().optional(),
+			method: z.string().optional(),
+			rootMethod: z.string().optional(),
 		}),
 		customTag: z.string().optional(),
 		overrideMe: z.string().optional(),
@@ -102,8 +102,8 @@ describe('@WithLogTags', () => {
 		// Method to test tag override precedence
 		@WithLogTags<TestTags>({
 			$logger: {
-				methodName: 'userAttempt', // Should be overridden
-				rootMethodName: 'userAttemptRoot', // Should be overridden
+				method: 'userAttempt', // Should be overridden
+				rootMethod: 'userAttemptRoot', // Should be overridden
 			},
 			overrideMe: 'decoratorValue',
 		})
@@ -212,7 +212,7 @@ describe('@WithLogTags', () => {
 		}
 	}
 
-	it('should add basic tags ($logger.methodName, $logger.rootMethodName, source)', async () => {
+	it('should add basic tags ($logger.method, $logger.rootMethod, source)', async () => {
 		const h = setupTest<TestTags>()
 		const service = new TestService(h)
 
@@ -221,8 +221,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(0).tags).toEqual({
 			source: 'TestServiceEntry',
 			$logger: {
-				methodName: 'entryPoint',
-				rootMethodName: 'entryPoint',
+				method: 'entryPoint',
+				rootMethod: 'entryPoint',
 			},
 			requestId: 'req-1',
 		})
@@ -249,8 +249,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(0).tags).toEqual({
 			source: 'TestServiceEntry',
 			$logger: {
-				methodName: 'entryPoint',
-				rootMethodName: 'entryPoint',
+				method: 'entryPoint',
+				rootMethod: 'entryPoint',
 			},
 			requestId: 'req-2',
 		})
@@ -260,8 +260,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(1).tags).toEqual({
 			source: 'TestServiceEntry', // Inherited source
 			$logger: {
-				methodName: 'nestedMethod',
-				rootMethodName: 'entryPoint',
+				method: 'nestedMethod',
+				rootMethod: 'entryPoint',
 			},
 			requestId: 'req-2', // Inherited from entryPoint context
 			customTag: 'nestedValue', // From decorator options
@@ -277,8 +277,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(3).tags).toEqual({
 			source: 'DeepNestedSource', // Overridden source
 			$logger: {
-				methodName: 'deeplyNestedMethod',
-				rootMethodName: 'entryPoint',
+				method: 'deeplyNestedMethod',
+				rootMethod: 'entryPoint',
 			},
 			requestId: 'req-2', // Inherited
 			customTag: 'nestedValue', // Inherited
@@ -311,8 +311,8 @@ describe('@WithLogTags', () => {
 			// Should not include tags set in nested contexts
 			source: 'TestServiceEntry',
 			$logger: {
-				methodName: 'entryPoint',
-				rootMethodName: 'entryPoint',
+				method: 'entryPoint',
+				rootMethod: 'entryPoint',
 			},
 			requestId: 'req-2',
 			// no customTag or userId that were set in nested call
@@ -332,8 +332,8 @@ describe('@WithLogTags', () => {
 		expect(h.oneLog().message).toBe('this.instanceValue is now: modified')
 		expect(h.oneLog().tags).toEqual({
 			$logger: {
-				methodName: 'methodAccessingThis',
-				rootMethodName: 'methodAccessingThis',
+				method: 'methodAccessingThis',
+				rootMethod: 'methodAccessingThis',
 			},
 			source: 'TestService', // inferred
 		})
@@ -359,8 +359,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(0).tags).toEqual({
 			source: 'StaticContext',
 			$logger: {
-				methodName: 'staticMethod',
-				rootMethodName: 'staticMethod',
+				method: 'staticMethod',
+				rootMethod: 'staticMethod',
 			},
 		})
 		expect(h.logAt(1).message).toBe('Exiting staticMethod')
@@ -378,8 +378,8 @@ describe('@WithLogTags', () => {
 		expect(h.oneLog().tags).toEqual({
 			source: 'ErrorSource',
 			$logger: {
-				methodName: 'methodWithError',
-				rootMethodName: 'methodWithError',
+				method: 'methodWithError',
+				rootMethod: 'methodWithError',
 			},
 		})
 	})
@@ -393,8 +393,8 @@ describe('@WithLogTags', () => {
 		expect(h.oneLog().tags).toEqual({
 			// $logger tags take precedence over decorator opts.tags
 			$logger: {
-				methodName: 'methodWithTagOverrides',
-				rootMethodName: 'methodWithTagOverrides',
+				method: 'methodWithTagOverrides',
+				rootMethod: 'methodWithTagOverrides',
 			},
 			// setTags takes precedence over decorator opts.tags
 			overrideMe: 'setTagsValue',
@@ -426,8 +426,8 @@ describe('@WithLogTags', () => {
 		const expectedTags = {
 			source: 'SyncSource',
 			$logger: {
-				methodName: 'synchronousMethod',
-				rootMethodName: 'synchronousMethod',
+				method: 'synchronousMethod',
+				rootMethod: 'synchronousMethod',
 			},
 			syncTag: true,
 		}
@@ -451,8 +451,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(0).tags).toEqual({
 			source: 'SyncCaller',
 			$logger: {
-				methodName: 'synchronousCaller',
-				rootMethodName: 'synchronousCaller',
+				method: 'synchronousCaller',
+				rootMethod: 'synchronousCaller',
 			},
 		})
 
@@ -461,8 +461,8 @@ describe('@WithLogTags', () => {
 		expect(h.logAt(1).tags).toEqual({
 			source: 'SyncSource', // Overrides caller's source
 			$logger: {
-				methodName: 'synchronousMethod', // Current method
-				rootMethodName: 'synchronousCaller', // Root is the caller
+				method: 'synchronousMethod', // Current method
+				rootMethod: 'synchronousCaller', // Root is the caller
 			},
 			syncTag: true, // Added by synchronousMethod decorator
 		})
@@ -478,8 +478,8 @@ describe('@WithLogTags', () => {
 			// excluding tags added by the nested call's decorator
 			source: 'SyncCaller',
 			$logger: {
-				methodName: 'synchronousCaller',
-				rootMethodName: 'synchronousCaller',
+				method: 'synchronousCaller',
+				rootMethod: 'synchronousCaller',
 			},
 		})
 	})
@@ -496,8 +496,8 @@ describe('@WithLogTags', () => {
 		expect(h.oneLog().message).toBe('this.syncInstanceValue is now: sync modified')
 		expect(h.oneLog().tags).toEqual({
 			$logger: {
-				methodName: 'syncMethodAccessingThis',
-				rootMethodName: 'syncMethodAccessingThis',
+				method: 'syncMethodAccessingThis',
+				rootMethod: 'syncMethodAccessingThis',
 			},
 			source: 'TestService', // inferred
 		})
@@ -510,8 +510,8 @@ describe('@WithLogTags', () => {
 			service.inferredSourceInstanceMethod()
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceInstanceMethod')
-			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('inferredSourceInstanceMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('inferredSourceInstanceMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethod).toBe('inferredSourceInstanceMethod')
 		})
 
 		it('should infer source from class name for static method when no options provided', () => {
@@ -519,8 +519,8 @@ describe('@WithLogTags', () => {
 			TestService.inferredSourceStaticMethod(h)
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceStaticMethod')
-			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('inferredSourceStaticMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('inferredSourceStaticMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethod).toBe('inferredSourceStaticMethod')
 		})
 
 		it('should infer source from class name when empty options object provided', () => {
@@ -529,7 +529,7 @@ describe('@WithLogTags', () => {
 			service.inferredSourceEmptyOptions()
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceEmptyOptions')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('inferredSourceEmptyOptions')
 		})
 
 		it('should infer source from class name when only tags option provided', () => {
@@ -539,7 +539,7 @@ describe('@WithLogTags', () => {
 
 			expect(h.oneLog().tags?.source).toBe('TestService')
 			expect(h.oneLog().tags?.only).toBe('tags') // Verify tag is also present
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('inferredSourceOnlyTags')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('inferredSourceOnlyTags')
 		})
 
 		it('should use explicit source from options object over inferred class name', () => {
@@ -548,7 +548,7 @@ describe('@WithLogTags', () => {
 			service.explicitSourceViaObject()
 
 			expect(h.oneLog().tags?.source).toBe('ExplicitSourceFromObject')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceViaObject')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('explicitSourceViaObject')
 		})
 
 		it('should use explicit source from string argument over inferred class name', () => {
@@ -557,7 +557,7 @@ describe('@WithLogTags', () => {
 			service.explicitSourceViaString()
 
 			expect(h.oneLog().tags?.source).toBe('ExplicitSourceFromString')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceViaString')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('explicitSourceViaString')
 		})
 
 		it('should use explicit source for static method when provided', () => {
@@ -565,7 +565,7 @@ describe('@WithLogTags', () => {
 			TestService.explicitSourceStaticMethod(h)
 
 			expect(h.oneLog().tags?.source).toBe('ExplicitStaticSource')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceStaticMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('explicitSourceStaticMethod')
 		})
 	})
 
@@ -579,14 +579,14 @@ describe('@WithLogTags', () => {
 			// Log 1: Outer method with its explicit source
 			expect(h.logAt(0).message).toBe('Entering outer explicit')
 			expect(h.logAt(0).tags?.source).toBe('OuterExplicitSource')
-			expect(toTags(h.logAt(0).tags)?.$logger.methodName).toBe('callNestedInferredSource')
+			expect(toTags(h.logAt(0).tags)?.$logger.method).toBe('callNestedInferredSource')
 
 			// Log 2: Inner method (@WithLogTags() - no explicit source)
 			// Should inherit 'OuterExplicitSource' from the ALS context
 			expect(h.logAt(1).message).toBe('Entering nested inferred (should inherit)')
 			expect(h.logAt(1).tags?.source).toBe('OuterExplicitSource') // Inherited
-			expect(toTags(h.logAt(1).tags)?.$logger.methodName).toBe('nestedInferredSource') // Own method name
-			expect(toTags(h.logAt(1).tags)?.$logger.rootMethodName).toBe('callNestedInferredSource') // Root is the caller
+			expect(toTags(h.logAt(1).tags)?.$logger.method).toBe('nestedInferredSource') // Own method name
+			expect(toTags(h.logAt(1).tags)?.$logger.rootMethod).toBe('callNestedInferredSource') // Root is the caller
 
 			// Log 3: Back in outer method
 			expect(h.logAt(2).message).toBe('Exiting outer explicit')
@@ -607,7 +607,7 @@ describe('@WithLogTags', () => {
 			// Should use its own explicit source, overriding the inherited one
 			expect(h.logAt(1).message).toBe('Entering nested explicit (should override)')
 			expect(h.logAt(1).tags?.source).toBe('InnerExplicitSource') // Overridden
-			expect(toTags(h.logAt(1).tags)?.$logger.methodName).toBe('nestedExplicitSource')
+			expect(toTags(h.logAt(1).tags)?.$logger.method).toBe('nestedExplicitSource')
 
 			// Log 3: Back in outer method
 			expect(h.logAt(2).message).toBe('Exiting outer explicit')
@@ -624,8 +624,8 @@ describe('@WithLogTags', () => {
 
 			expect(h.oneLog().message).toBe('Running generic inferred method')
 			expect(h.oneLog().tags?.source).toBe('TestService') // Inferred from class
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('genericInferredMethod')
-			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethod).toBe('genericInferredMethod')
 		})
 
 		it('should inherit source from withLogTags context if decorator has no explicit source', async () => {
@@ -640,9 +640,9 @@ describe('@WithLogTags', () => {
 			expect(h.oneLog().message).toBe('Running generic inferred method')
 			// Should inherit source from the withLogTags context
 			expect(h.oneLog().tags?.source).toBe('FromWithLogTags')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('genericInferredMethod')
 			// Root method name starts when the first decorator runs
-			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('genericInferredMethod')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethod).toBe('genericInferredMethod')
 		})
 
 		it('should use decorator explicit source even when called from withLogTags context', async () => {
@@ -657,8 +657,8 @@ describe('@WithLogTags', () => {
 			expect(h.oneLog().message).toBe('Instance method with explicit source (object)')
 			// Decorator's explicit source should take precedence over withLogTags context
 			expect(h.oneLog().tags?.source).toBe('ExplicitSourceFromObject')
-			expect(toTags(h.oneLog().tags)?.$logger.methodName).toBe('explicitSourceViaObject')
-			expect(toTags(h.oneLog().tags)?.$logger.rootMethodName).toBe('explicitSourceViaObject')
+			expect(toTags(h.oneLog().tags)?.$logger.method).toBe('explicitSourceViaObject')
+			expect(toTags(h.oneLog().tags)?.$logger.rootMethod).toBe('explicitSourceViaObject')
 		})
 	})
 })


### PR DESCRIPTION
this will save a lot of bytes in the long run