### PR TITLE
fix(workers-tagged-logger): fix multi-arg message stringification and colo tag nesting

### DIFF
--- a/npm-pkgs/workers-tagged-logger/src/hono.spec.ts
+++ b/npm-pkgs/workers-tagged-logger/src/hono.spec.ts
@@ -54,6 +54,32 @@ describe('useWorkersLogger()', () => {
 		`)
 	})
 
+	it('sets colo tag as a flat string from request cf properties', async () => {
+		const h = setupTest()
+		const app = new Hono<App>()
+			.use(async (c, next) => {
+				c.env = { ENVIRONMENT: 'production' }
+				await next()
+			})
+			.use(useWorkersLogger('worker-a'))
+			.get(async (c) => {
+				h.log.info('hi')
+				return c.text('hello')
+			})
+
+		const req = new Request('https://example.com')
+		Object.defineProperty(req, 'cf', { value: { colo: 'DFW' }, writable: false })
+
+		const res = await app.fetch(req)
+		expect(await res.text()).toBe('hello')
+		expect(res.status).toBe(200)
+
+		const tags = h.oneLog().tags
+		expect(tags).toBeDefined()
+		expect(tags!.colo).toBe('DFW')
+		expect(tags!.environment).toBe('production')
+	})
+
 	it('does not add environment when not present in bindings', async () => {
 		const h = setupTest()
 		const app = new Hono<App>().use(useWorkersLogger('worker-a')).get(async (c) => {

--- a/npm-pkgs/workers-tagged-logger/src/hono.ts
+++ b/npm-pkgs/workers-tagged-logger/src/hono.ts
@@ -34,9 +34,9 @@ export function useWorkersLogger<T extends LogTags>(
 				}
 			}
 
-			const colo = getCfFromRequest(c.req.raw)
-			if (colo !== null) {
-				log.setTags({ colo })
+			const cfProps = getCfFromRequest(c.req.raw)
+			if (cfProps !== null) {
+				log.setTags({ colo: cfProps.colo })
 			}
 
 			if (tags !== undefined) {

--- a/npm-pkgs/workers-tagged-logger/src/logger.ts
+++ b/npm-pkgs/workers-tagged-logger/src/logger.ts
@@ -322,7 +322,7 @@ export class WorkersLogger<T extends LogTags> implements LogLevelFns {
 			} else if (msgs.length === 1) {
 				message = stringifyMessage(msgs[0])
 			} else {
-				message = stringifyMessages(msgs)
+				message = stringifyMessages(...msgs)
 			}
 		}
 

--- a/npm-pkgs/workers-tagged-logger/src/test/logger/logger.spec.ts
+++ b/npm-pkgs/workers-tagged-logger/src/test/logger/logger.spec.ts
@@ -136,11 +136,11 @@ describe('WorkersLogger', () => {
 		test('multiple values are logged to the same log', async () => {
 			const h = setupTest()
 			await withLogTags({ source: 'worker-a' }, async () => {
-				h.log.info('hello', 123, new Error('boom!'), { banda: 'rocks' }, ['a', 'b'], {
+				h.log.info('hello', 123, 'error occurred', { banda: 'rocks' }, ['a', 'b'], {
 					foo: { bar: { baz: 'abc' } },
 				})
 				expect(h.oneLog().message).toMatchInlineSnapshot(
-					`"["hello",123,{},{"banda":"rocks"},["a","b"],{"foo":{"bar":{"baz":"abc"}}}]"`
+					`"hello 123 error occurred {"banda":"rocks"} ["a","b"] {"foo":{"bar":{"baz":"abc"}}}"`
 				)
 			})
 		})


### PR DESCRIPTION
# THIS IS AN AI TEST PR DO NOT MERGE

The `write()` method in `WorkersLogger` calls `stringifyMessages(msgs)` without spreading the array, so the rest-parameter function receives `[[msg1, msg2]]` instead of `[msg1, msg2]`. This causes multi-argument log calls like `log.info('hello', 123, {foo: 'bar'})` to produce a single JSON-stringified array string instead of space-separated individually-stringified messages. The fix is a one-character change: `stringifyMessages(msgs)` → `stringifyMessages(...msgs)`.

Separately, `getCfFromRequest()` returns a `CfProps` object (`{ colo: string }`) but the Hono middleware sets it via shorthand `{ colo }`, creating a nested `{ colo: { colo: "DFW" } }` tag instead of the intended `{ colo: "DFW" }`. This is fixed by extracting the string: `{ colo: cfProps.colo }`.

The existing test snapshot for multi-value logging reflected the buggy behavior and has been updated. The `new Error('boom!')` argument was replaced with a plain string in that test since Error stringification is already covered by dedicated tests in `stringifyMessages()`. A new test verifies the colo tag is set as a flat string when the request has `cf` properties.

<!-- codesmith:footer -->
<a href="https://app.blacksmith.sh/jahands/codesmith/workers-packages/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable auto-fix issues.</sup>

- [x] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case verifying colo tag extraction from Cloudflare request properties alongside environment tags
  * Updated test validating multi-argument log message formatting

* **Improvements**
  * Tagged logger now extracts colo tag information from Cloudflare request properties
  * Enhanced message formatting for multi-argument log entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->