### PR TITLE
fix: embed sourcesContent in published .js.map files

### DIFF
--- a/.changeset/inline-sourcemap-sources.md
+++ b/.changeset/inline-sourcemap-sources.md
@@ -1,0 +1,18 @@
+---
+'workers-tagged-logger': patch
+'@jahands/cli-tools': patch
+'@jahands/dagger-helpers': patch
+'dagger-env': patch
+'http-codex': patch
+'llm-tools': patch
+'notion-schemas': patch
+'opencode-plugin-cloudflare': patch
+'yaplib': patch
+---
+
+fix: embed sourcesContent in published .js.map files
+
+Enable `inlineSources` in the shared lib-emit tsconfig so that published
+source maps embed source content rather than referencing `../src/*.ts`
+files that aren't included in the npm tarball. Resolves bundler warnings
+(e.g. Vite) when consuming these packages.

--- a/npm-pkgs/cli-tools/.npmignore
+++ b/npm-pkgs/cli-tools/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/cli-tools/package.json
+++ b/npm-pkgs/cli-tools/package.json
@@ -111,7 +111,8 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts",

--- a/npm-pkgs/dagger-env/.npmignore
+++ b/npm-pkgs/dagger-env/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/dagger-env/package.json
+++ b/npm-pkgs/dagger-env/package.json
@@ -44,7 +44,8 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts ./src/op.ts ./src/run-dagger-cmd.ts",

--- a/npm-pkgs/dagger-helpers/.npmignore
+++ b/npm-pkgs/dagger-helpers/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/dagger-helpers/package.json
+++ b/npm-pkgs/dagger-helpers/package.json
@@ -32,7 +32,8 @@
 	"main": "./dist/index.mjs",
 	"module": "./dist/index.mjs",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build bundle-lib ./src/index.ts --format esm --platform node",

--- a/npm-pkgs/http-codex/.npmignore
+++ b/npm-pkgs/http-codex/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/http-codex/package.json
+++ b/npm-pkgs/http-codex/package.json
@@ -47,7 +47,8 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts ./src/status.ts ./src/method.ts",

--- a/npm-pkgs/llm-tools/.npmignore
+++ b/npm-pkgs/llm-tools/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/llm-tools/package.json
+++ b/npm-pkgs/llm-tools/package.json
@@ -41,7 +41,8 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts",

--- a/npm-pkgs/notion-schemas/.npmignore
+++ b/npm-pkgs/notion-schemas/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/notion-schemas/package.json
+++ b/npm-pkgs/notion-schemas/package.json
@@ -31,7 +31,8 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts",

--- a/npm-pkgs/opencode-plugin-cloudflare/.npmignore
+++ b/npm-pkgs/opencode-plugin-cloudflare/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/opencode-plugin-cloudflare/package.json
+++ b/npm-pkgs/opencode-plugin-cloudflare/package.json
@@ -19,7 +19,8 @@
 	"type": "module",
 	"main": "./dist/cloudflare.js",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/cloudflare.ts",

--- a/npm-pkgs/workers-tagged-logger/.npmignore
+++ b/npm-pkgs/workers-tagged-logger/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/workers-tagged-logger/package.json
+++ b/npm-pkgs/workers-tagged-logger/package.json
@@ -48,7 +48,8 @@
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts ./src/ts5-decorator.ts",

--- a/npm-pkgs/yaplib/.npmignore
+++ b/npm-pkgs/yaplib/.npmignore
@@ -1,0 +1,9 @@
+# Exclude test files from the published src/ tree.
+# The src/ folder is shipped so that the .d.ts.map files
+# bundled in dist/ can resolve their original TypeScript
+# sources for editor "Go to Definition".
+*.spec.ts
+*.test.ts
+test/
+__tests__/
+examples/

--- a/npm-pkgs/yaplib/package.json
+++ b/npm-pkgs/yaplib/package.json
@@ -39,7 +39,8 @@
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"scripts": {
 		"build": "runx build tsc ./src/index.ts",

--- a/packages/typescript-config/lib-emit.json
+++ b/packages/typescript-config/lib-emit.json
@@ -27,6 +27,7 @@
 		"outDir": "${configDir}/dist",
 		// "rootDir": "${configDir}/src",
 		"sourceMap": true,
+		"inlineSources": true,
 
 		// AND if you're building for a library:
 		"declaration": true,


### PR DESCRIPTION
Closes #177.

`packages/typescript-config/lib-emit.json` was emitting source maps with `sourceMap: true` but not `inlineSources`, so the published `dist/*.js.map` files referenced `../src/*.ts` paths that aren't shipped in the tarball (`files: ["dist"]`). Bundlers like Vite warn when they try to resolve those missing sources. This adds `"inlineSources": true` to the shared tsc config so the source content is embedded directly in each `.js.map`.

How it works:
- `inlineSources` builds on the existing `sourceMap` setting and tells tsc to write the original TypeScript content into the `sourcesContent` field of each emitted map.
- The change lives in the shared `lib-emit.json`, so every package that extends it (`workers-tagged-logger`, `yaplib`, `notion-schemas`, `llm-tools`, `http-codex`, `dagger-helpers`, `opencode-plugin-cloudflare`, `cli-tools`, `dagger-env`) picks up the fix on its next build, not just the package called out in the issue.
- A changeset patch-bumps each affected package so the next release ships the corrected maps.

This is option 1 from the issue (the cleanest of the three). It doesn't alter the publish file list and doesn't drop source maps, so consumers keep working source maps and the warnings go away. The on-disk map size grows by roughly the size of each `src/*.ts` file, which is small for these packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed source map configuration to eliminate bundler warnings when consuming these packages. Source content is now embedded directly in source maps rather than referencing external source files that are absent from npm distributions. This ensures complete debugging information is available and packages integrate smoothly with build tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jahands/workers-packages/pull/178)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->